### PR TITLE
Fix masking logic for file output

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,11 @@ try {
     shouldRecurse,
   });
 
+  // Mask secrets in GitHub logs
+  Object.entries(keyValueSecrets).forEach(([, value]) => {
+    core.setSecret(value);
+  });
+
   core.debug(
     `Exporting the following envs", ${JSON.stringify(
       Object.keys(keyValueSecrets)
@@ -68,7 +73,6 @@ try {
   if (exportType === "env") {
     // Write the secrets to action ENV
     Object.entries(keyValueSecrets).forEach(([key, value]) => {
-      core.setSecret(value);
       core.exportVariable(key, value);
     });
     core.info("Injected secrets as environment variables");


### PR DESCRIPTION
When using `export-type: file`, the retrieved secret values can be seen in the GitHub logs by using `cat .env`. This PR moves the masking logic above the export logic which will fix the issue and show masked values instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved security measures: Sensitive information is now masked in logs before any logging occurs, ensuring enhanced protection of confidential data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->