### PR TITLE
Fix absolute path handling for file-output-path and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Exports secrets to a file in your `GITHUB_WORKSPACE`, useful for applications th
     env-slug: "dev"
     project-slug: "cli-integration-tests-9-edj"
     export-type: "file"
-    file-output-path: "/src/.env" # defaults to "/.env"
+    file-output-path: "/src/.env" # Path relative to GITHUB_WORKSPACE; leading slashes will be stripped
 ```
 
 **Note**: Make sure to configure an `actions/checkout` step before using this action in file export mode

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import core from "@actions/core";
 import { UALogin, getRawSecrets, oidcLogin } from "./infisical.js";
 import fs from "fs/promises";
+import path from "path";
 
 try {
   const method = core.getInput("method");

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ try {
       .join("\n");
 
     try {
-      const filePath = `${process.env.GITHUB_WORKSPACE}${fileOutputPath}`;
+      const filePath = path.join(process.env.GITHUB_WORKSPACE, fileOutputPath);
       core.info(`Exporting secrets to ${filePath}`);
       await fs.writeFile(filePath, fileContent);
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ try {
       .join("\n");
 
     try {
-      const filePath = path.join(process.env.GITHUB_WORKSPACE, fileOutputPath);
+      const filePath = path.join(process.env.GITHUB_WORKSPACE, fileOutputPath.replace(/^\/+/, ""));
       core.info(`Exporting secrets to ${filePath}`);
       await fs.writeFile(filePath, fileContent);
     } catch (err) {


### PR DESCRIPTION
📝 PR Description:

This PR fixes an issue where using a leading / in file-output-path would result in an invalid path like /home/runner/work/myrepo/myrepo//src/.env, causing file export to silently fail.

Changes:

    Replaces string concatenation with path.join() to handle file paths more robustly.

    Strips any leading / from file-output-path before joining with GITHUB_WORKSPACE.

    Updates README to clarify that file-output-path should be relative and that leading slashes will be stripped.

This change makes the action more resilient and user-friendly, especially for folks expecting absolute-like paths to "just work™️".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified in the README that the file output path is relative to the workspace and leading slashes will be stripped.

- **Bug Fixes**
  - Improved file path handling to ensure output paths are correctly normalized, regardless of leading slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->